### PR TITLE
Add the ability to pay to P2SH addresses

### DIFF
--- a/core/base58.c
+++ b/core/base58.c
@@ -448,10 +448,13 @@ b58_privkey_to_bytes(const char *addr,
  *
  *      Decodes a bitcoin address and retrieve the encode pubkey hash.
  *
+ * Returns:
+ *      The type of address decoded.
+ *
  *------------------------------------------------------------------------
  */
 
-void
+uint8
 b58_pubkey_to_uint160(const char *addr,
                       uint160 *digest)
 {
@@ -460,10 +463,11 @@ b58_pubkey_to_uint160(const char *addr,
    uint8 type;
 
    base58_decode_check(&type, addr, &buf, &len);
-   ASSERT(type == PUBKEY_ADDRESS);
+   ASSERT(type == PUBKEY_ADDRESS || type == SCRIPT_ADDRESS);
    if (len == sizeof *digest) {
       memcpy(digest, buf, sizeof *digest);
    }
    free(buf);
+   return type;
 }
 

--- a/core/base58.h
+++ b/core/base58.h
@@ -13,7 +13,7 @@ enum key_address {
 };
 
 char *b58_pubkey_from_uint160(const uint160 *digest);
-void  b58_pubkey_to_uint160(const char *addr, uint160 *digest);
+uint8 b58_pubkey_to_uint160(const char *addr, uint160 *digest);
 bool  b58_pubkey_is_valid(const char *addr);
 bool  b58_privkey_to_bytes(const char *addr, uint8 **key, size_t *keylen);
 char *b58_bytes_to_privkey(const uint8 *key, size_t len);

--- a/core/script.h
+++ b/core/script.h
@@ -28,6 +28,7 @@ enum script_opcode {
    // push value
    OP_0         = 0x00,
    OP_FALSE     = OP_0,
+   OP_PUSH20    = 0x14,
    OP_PUSHDATA1 = 0x4c,
    OP_PUSHDATA2 = 0x4d,
    OP_PUSHDATA4 = 0x4e,
@@ -167,7 +168,8 @@ enum script_opcode {
 };
 
 
-int script_txo_generate(const uint160 *pubkey, uint8 **script, uint64 *len);
+int script_txo_generate(uint8 type, const uint160 *pubkey, uint8 **script,
+                        uint64 *len);
 int script_sign(struct wallet *wallet, const struct btc_msg_tx_out *txo,
                 struct btc_msg_tx *tx, uint32 idx, enum script_hash_type hashType);
 int script_parse_pubkey_hash(const uint8 *scriptPubKey, size_t scriptLength,

--- a/core/txdb.c
+++ b/core/txdb.c
@@ -1237,15 +1237,17 @@ txdb_set_txo(btc_msg_tx *tx,
 {
    struct btc_msg_tx_out *txo;
    uint160 pubkey;
+   uint8 type;
 
-   b58_pubkey_to_uint160(btc_addr, &pubkey);
+   type = b58_pubkey_to_uint160(btc_addr, &pubkey);
    Log_Bytes(LGPFX" hash-addr:", &pubkey, sizeof pubkey);
 
    ASSERT(idx < tx->out_count);
    txo = tx->tx_out + idx;
    txo->value = value;
 
-   script_txo_generate(&pubkey, &txo->scriptPubKey, &txo->scriptLength);
+   script_txo_generate(type, &pubkey, &txo->scriptPubKey,
+                       &txo->scriptLength);
 }
 
 


### PR DESCRIPTION
This patch enables bitc to formulate transactions with the correct script for P2SH recipient addresses.
